### PR TITLE
Add JSON output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Workload driver options - for wrk2:
 Output format options:
 - `INTERVAL` - frequency of RSS measurements (seconds), and throughput (if supported)
 - `RSS_TRACE` - if set, generates a CSV of periodic RSS measurements
+- `CPU_TRACE` - if set, generates a CSV of periodic CPU measurements
 
 ###Customizing the drive.sh script
 
@@ -57,15 +58,25 @@ Before using this script, there are a number of hard-coded settings that you sho
 - The original output from `drive.sh` is preserved in a series of files named `compares/<date>/compare_<iteration no>_<app no>.out`.
 - Compares can be customized by setting various environment variables:
 ```
+  DRIVER: workload driver to use (default: wrk)
   ITERATIONS: number of repetitions of each implementation (default: 5)
   URL: url to drive load against (default: http://127.0.0.1:8080/plaintext)
+  CLIENT: server to use to execute load driver (default: localhost)
   CPUS: list of CPUs to affinitize to (default: 0,1,2,3)
   CLIENTS: # of concurrent clients (default: 128)
   DURATION: time (sec) to apply load (default: 30)
+  SLEEP: time (sec) to wait between tests (default: 5)
+  RUNNAME: name of directory to store results (default: compares/YYYYMMDD-HHmmss)
+Output control:
+  RSS_TRACE: set to enable production of periodic RSS values in CSV format
+  CPU_TRACE: set to enable periodic CPU values in CSV format
+  THROUGHPUT_TRACE: set to enable periodic throughput values in CSV format
+  CPU_STATS: set to report total/user/sys CPU time consumed by application
+  JSONFILE: fully-qualified filename to write results to in JSON format
 ```
 ...in addition, the environment variables consumed by `drive.sh` can also be specified.
 
-If you require multiple instances of the application, specify the application path and number of instances separated by a comma, for example: `/path/to/executable,iterations`
+If you require multiple instances of the application, specify the application path and number of instances separated by a comma, for example: `/my/app,4` to run 4 instances of /my/app
 
 ##Example output
 
@@ -78,6 +89,8 @@ Implementation | Avg Throughput | Max Throughput | Avg CPU | Avg RSS (kb)
              3 |         3196.4 |        3196.90 |    10.1 |        42287
  ```
 This is a simple summarization of the output from each run of each implementation. Further details for each measurement can be found by examining the `compare_<iteration no>_<app no>.out` files.
+
+If `JSONFILE` is specified, the JSON-formatted output will be written to this file in addition to the normal output described above.
 
 ###Regenerating the output from a previous compare
 
@@ -92,6 +105,7 @@ You can set the environment variable `DRIVER` to either
 - wrk (https://github.com/wg/wrk) - highly efficient, variable-rate load generator
 - wrk2 (https://github.com/giltene/wrk2) - fixed-rate wrk variant with accurate latency stats
 - jmeter (http://jmeter.apache.org/) - highly customizable Java-based load generator
+- sleep - drive no load (allows for monitoring of idle resource consumption)
 
 By default, 'wrk' is used to drive load.  Ensure that the command is available in your PATH.
 

--- a/compare.sh
+++ b/compare.sh
@@ -162,12 +162,10 @@ json_object_end
 mkdir -p $WORKDIR/runs
 
 # Execute tests
-json_object_start "Iterations"
 for i in `seq 1 $ITERATIONS`; do
-  json_object_start "$i"
-  json_object_start "Implementations"
+  json_object_start "Iteration $i"
   for j in `seq 1 $IMPLC`; do
-    json_object_start "$j"
+    json_object_start "Implementation $j"
     echo "Iteration $i: Implementation $j"
     run="${i}_${j}"
     let runNo=($i-1)*$IMPLC+$j
@@ -237,10 +235,8 @@ for i in `seq 1 $ITERATIONS`; do
     fi
     json_object_end  # end implementation
   done
-  json_object_end    # end implementations
   json_object_end    # end iteration
 done
-json_object_end      # end iterations
 
 # Summarize
 # TODO: add JSON summary

--- a/compare.sh
+++ b/compare.sh
@@ -43,6 +43,7 @@ if [ -z "$1" ]; then
   echo "  CPU_TRACE: set to enable periodic CPU values in CSV format"
   echo "  THROUGHPUT_TRACE: set to enable periodic throughput values in CSV format"
   echo "  CPU_STATS: set to report total/user/sys CPU time consumed by application"
+  echo "  JSONFILE: fully-qualified filename to write results to in JSON format"
   echo "Instance control:"
   echo "  To run multiple instances of the application, add a comma and a number to the"
   echo "  filename, eg: /my/app,4 to run 4 instances of /my/app"

--- a/drive.sh
+++ b/drive.sh
@@ -140,6 +140,7 @@ if [ -z "$1" -o "$1" == "--help" ]; then
   echo "Output format options:"
   echo "  INTERVAL - frequency of RSS measurements (seconds), and throughput (if supported)"
   echo "  RSS_TRACE - if set, generates a CSV of periodic RSS measurements"
+  echo "  CPU_TRACE - if set, generates a CSV of periodic CPU measurements"
   echo ""
   exit 1
 fi

--- a/drive.sh
+++ b/drive.sh
@@ -714,6 +714,8 @@ function startup() {
     RSSMON_PIDS="$! $RSSMON_PIDS"
   done
   RSSMON_COUNT=$i
+  # Report how many processes are executing as a result of starting the server
+  echo "Total server processes: $i"
 }
 
 #
@@ -902,7 +904,7 @@ for i in `seq 1 $RSSMON_COUNT`; do
   let RSS_DIFF=$RSS_END-$RSS_START
   echo "$i: RSS (kb): start=$RSS_START end=$RSS_END delta=$RSS_DIFF max=$RSS_HIGH_WATER_MARK" | tee -a mem.log
   if [ ! -z "$RSS_TRACE" ]; then
-    echo -n "RSS_TRACE[$i]: "
+    echo -n "$i: RSS_TRACE: "
     cat rssout${i}.txt | awk 'BEGIN {r=""} {r=r $1 ","} END {print r}'
   fi
 done

--- a/lib/json_output.sh
+++ b/lib/json_output.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Copyright IBM Corporation 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+let JSON_ENABLED=0
+let JSON_INDENT=0
+let JSON_COMMA=0
+JSON_OUTPUT=""
+
+#
+# Sets the output filename to write, and enables JSON output
+# Param 1: name of file
+#
+function json_set_file {
+  JSON_OUTPUT="$1"
+  let JSON_ENABLED=1
+  let JSON_INDENT=0
+  let JSON_COMMA=0
+}
+
+#
+# Disables JSON output
+#
+function json_stop {
+  JSON_OUTPUT=""
+  let JSON_ENABLED=0
+}
+
+#
+# Output {
+# - and increase indent level
+#
+function json_start {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  json_indent
+  printf "{\n" > $JSON_OUTPUT
+  let JSON_INDENT=$JSON_INDENT+1
+}
+
+#
+# Output }
+# - and decrease indent level
+#
+function json_end {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  while [ $JSON_INDENT -gt 0 ]; do
+    let JSON_INDENT=$JSON_INDENT-1
+    printf "\n" >> $JSON_OUTPUT
+    json_indent
+    printf "}" >> $JSON_OUTPUT
+  done
+  printf "\n"
+}
+
+#
+# Output "string: "string"
+# - appending a comma to the previous value, if one is present
+# Param 1: name
+# Param 2: string
+#
+function json_string {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  json_comma
+  json_indent
+  printf "\"%s\": \"%s\"" "$1" "$2" >> $JSON_OUTPUT
+}
+
+#
+# Output "string": number
+# - appending a comma to the previous value, if one is present
+# Param 1: name
+# Param 2: number
+#
+function json_number {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  json_comma
+  json_indent
+  printf "\"%s\": %s" "$1" "$2" >> $JSON_OUTPUT
+}
+
+#
+# Output "name": {
+# - and increase indent level
+# Param 1: name
+#
+function json_object_start {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  json_comma
+  json_indent
+  printf "\"%s\": {\n" "$1" >> $JSON_OUTPUT
+  let JSON_COMMA=0
+  let JSON_INDENT=$JSON_INDENT+1
+}
+
+#
+# Output }
+# - and decrease indent level
+#
+function json_object_end {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  let JSON_INDENT=$JSON_INDENT-1
+  printf "\n" >> $JSON_OUTPUT
+  json_indent
+  printf "}" >> $JSON_OUTPUT
+  let JSON_COMMA=1
+}
+
+#
+# Indents the current line
+#
+function json_indent {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  let COUNTER=0
+  while [ $COUNTER -lt $JSON_INDENT ]; do
+    let COUNTER=$COUNTER+1
+    printf "    " >> $JSON_OUTPUT
+  done
+}
+
+#
+# Appends a command and newline if appropriate
+#
+function json_comma {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  if [ $JSON_COMMA -gt 0 ]; then
+    printf ",\n" >> $JSON_OUTPUT
+  fi
+  let JSON_COMMA=1
+}
+
+#
+# Writes an object containing the current environment
+#
+function json_env {
+  if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  json_object_start "Env"
+  TMPIFS="$IFS"
+  IFS="
+"
+  for ENVVAR in `env`; do
+    ENVKEY="`echo $ENVVAR | sed -e's#=.*##'`"
+    ENVVAL="`echo $ENVVAR | sed -e's#[^=]*=##'`"
+    json_string "$ENVKEY" "$ENVVAL"
+  done
+  IFS="$TMPIFS"
+  json_object_end
+}
+

--- a/lib/json_output.sh
+++ b/lib/json_output.sh
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+# Determine location of this script
+JSON_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. ${JSON_SCRIPT_DIR}/sanitize.sh
+
 let JSON_ENABLED=0
 let JSON_INDENT=0
 let JSON_COMMA=0
@@ -73,9 +78,13 @@ function json_end {
 #
 function json_string {
   if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  sanitize_string "$1"
+  JSON_KEY="$SANITIZED_STRING"
+  sanitize_string "$2"
+  JSON_VAL="$SANITIZED_STRING"
   json_comma
   json_indent
-  printf "\"%s\": \"%s\"" "$1" "$2" >> $JSON_OUTPUT
+  printf "\"%s\": \"%s\"" "$JSON_KEY" "$JSON_VAL" >> $JSON_OUTPUT
 }
 
 #
@@ -86,9 +95,13 @@ function json_string {
 #
 function json_number {
   if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  sanitize_string "$1"
+  JSON_KEY="$SANITIZED_STRING"
+  sanitize_string "$2"
+  JSON_VAL="$SANITIZED_STRING"
   json_comma
   json_indent
-  printf "\"%s\": %s" "$1" "$2" >> $JSON_OUTPUT
+  printf "\"%s\": %s" "$JSON_KEY" "$JSON_VAL" >> $JSON_OUTPUT
 }
 
 #
@@ -98,9 +111,11 @@ function json_number {
 #
 function json_object_start {
   if [ $JSON_ENABLED -eq 0 ]; then return; fi
+  sanitize_string "$1"
+  JSON_KEY="$SANITIZED_STRING"
   json_comma
   json_indent
-  printf "\"%s\": {\n" "$1" >> $JSON_OUTPUT
+  printf "\"%s\": {\n" "$JSON_KEY" >> $JSON_OUTPUT
   let JSON_COMMA=0
   let JSON_INDENT=$JSON_INDENT+1
 }

--- a/lib/sanitize.sh
+++ b/lib/sanitize.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# Sanitize a string, replacing special characters (newline, CR, double quotes)
+# with escaped versions, suitable for output in a JSON document.
+#
+# Param 1: the string to sanitize
+# Result: written to the SANITIZED_STRING variable
+#
+function sanitize_string() {
+    SANITIZED_STRING=$1
+    # escape backslashes
+    SANITIZED_STRING=${SANITIZED_STRING//$'\\'/\\\\}
+    # escape newlines
+    SANITIZED_STRING=${SANITIZED_STRING//$'\n'/\\n}
+    # escape carriage returns
+    SANITIZED_STRING=${SANITIZED_STRING//$'\r'/\\r}
+    # escape double quotes
+    SANITIZED_STRING=${SANITIZED_STRING//$'\"'/\\\"}
+
+    #if [ ! "$1" == "$SANITIZED_STRING" ]; then
+    #  echo "$1 was converted to $SANITIZED_STRING"
+    #fi
+}


### PR DESCRIPTION
Implements #5 

This PR adds a `JSONFILE` environment variable for `compare.sh` which enables the writing of results in a more consumable JSON format.

Also add missing command line documentation of a few output formatting options.