### PR TITLE
Detect failures in compare.sh

### DIFF
--- a/compare.sh
+++ b/compare.sh
@@ -191,6 +191,14 @@ for i in `seq 1 $ITERATIONS`; do
     fi
     json_string "Command" "./drive.sh compare_$run $CPUS $CLIENTS $DURATION ${IMPLS[$j]} $URL ${INSTANCES[$j]}"
 
+  # Don't parse output if iteration did not terminate successfully
+    if grep 'Detected successful termination' $out; then
+        json_string "Good iteration" "true"
+    else
+        echo "Ignoring iteration as did not terminate successfully"
+        json_string "Good iteration" "false"
+        continue
+    fi
     # Note, removal of carriage return chars (^M) required when client output comes from 'ssh -t'
     THROUGHPUT[$runNo]=`grep 'Requests/sec' $out | awk '{gsub("\\r", ""); print $2}'`
     CPU[$runNo]=`grep 'Average CPU util' $out | awk '{print $4}'`

--- a/drive.sh
+++ b/drive.sh
@@ -757,9 +757,11 @@ function shutdown() {
   for APP_PID in $APP_PIDS; do
     wait $APP_PID
     APP_RC=$?
-    # Expect RC=143 (128 + 15 = SIGTERM)
+  # Expect RC=143 (128 + 15 = SIGTERM)
     if [ $APP_RC -ne 143 ]; then
       echo "Detected unexpected termination: RC of $APP_PID = $APP_RC"
+    else 
+      echo "Detected successful termination of $APP_PID"
     fi
   done
 }


### PR DESCRIPTION
Output is ignored when iteration terminates unsuccessfully (with an unexpected return code). Result is also recorded in the json output in the "Good iteration" field. Fixes #6 