### PR TITLE
Jenkins Integration and Usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ Output control:
 ```
 ...in addition, the environment variables consumed by `drive.sh` can also be specified.
 
-If you require multiple instances of the application, specify the application path and number of instances separated by a comma, for example: `/my/app,4` to run 4 instances of /my/app
+Per-implementation options may be specified.  These follow the executable, comma-separated:
+```
+  instances=N: Run multiple instances of an application
+  label=SomeName: Used to name the application in the output
+  pwd=/some/directory: Specify the PWD for the application
+```
+Example: `/path/to/myExecutable,label=MyProg1,pwd=/tmp`
 
 ## Example output
 

--- a/compare.sh
+++ b/compare.sh
@@ -184,7 +184,7 @@ if [ ! -z "$JENKINS_URL" ]; then
   json_string "AUTOMATION_COMMIT" "$GIT_COMMIT"      # Set by Jenkins
   json_string "REPO" "$REPO"                         # Job parameter
   json_string "REPO_COMMIT" "$REPO_COMMIT"           # Set by automation
-  json_string "BUILD_RUN_ID" "$BUILD_RUN_ID"         # Set by automation
+  json_string "VERSION_ID" "$VERSION_ID"             # Set by automation
 fi
 json_object_end   # end configuration
 

--- a/compare.sh
+++ b/compare.sh
@@ -184,6 +184,7 @@ if [ ! -z "$JENKINS_URL" ]; then
   json_string "AUTOMATION_COMMIT" "$GIT_COMMIT"      # Set by Jenkins
   json_string "REPO" "$REPO"                         # Job parameter
   json_string "REPO_COMMIT" "$REPO_COMMIT"           # Set by automation
+  json_string "BASE_VERSION" "$BASE_VERSION"         # Set by automation
   json_string "VERSION_ID" "$VERSION_ID"             # Set by automation
 fi
 json_object_end   # end configuration


### PR DESCRIPTION
This PR does four things:

- Removes the `env` dump from the JSON, replacing with more selective information:  the `DRIVER` and `WRK_SCRIPT` / `JMETER_SCRIPT` params, which were not explicitly mentioned, the server's hostname, and - if running under Jenkins - a set of parameters determined by the automation which can be used by downstream tooling (dashboarding).
- Implements a new syntax for specifying per-implementation options:  a comma-separated list following the executable.  Eg: `/path/to/app,var1=value1,var2=value2`
  - the old way of setting instances with a comma followed by a number is gone, replaced with `instances=N` in the above syntax.
- A per-implementation option for setting the label associated with an implementation: `label=Baseline`.  This is purely cosmetic and replaces "Implementation 1" with (for example) "Baseline" in the output.
- A per-implementation option for setting the working directory of the application: `pwd=/some/path`.  If set, this will be the current directory when the app is launched.

### Unresolved issues

- Setting the PWD of the application changes the location of Linux core dumps (which are written to `PWD/core`). Core dumps will be overwritten if more than one execution produces one.  Mac cores are unaffected (they continue to go to /cores).
- Setting the PWD when a profiler is present will affect the location of the profiler's data, and the post-processing will fail to find it.  In a future PR we could detect that the PWD was changed and move the data (perhaps also moving a core, if one was generated).